### PR TITLE
Fix early free

### DIFF
--- a/panel.cpp
+++ b/panel.cpp
@@ -149,7 +149,6 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
     image->Merge(bg, X, Y);
     background = image->createPixmap(Dpy, Scr, Win);
     delete bg;
-    delete image;
 
     // Read (and substitute vars in) the welcome message
     int show_welcome_msg = Cfg::string2int(cfg->getOption("show_welcome_msg").c_str());
@@ -182,6 +181,7 @@ Panel::~Panel() {
     XftFontClose(Dpy, introfont);
     XftFontClose(Dpy, welcomefont);
     XftFontClose(Dpy, enterfont);
+    delete image;
 
     XFreeGC(Dpy, WinGC);
     XFreePixmap(Dpy, background);


### PR DESCRIPTION
image is freed after setup of the bg but its width and height values are still used later on, causing wrong relative calculations with percentages (and thus breaking some themes).

Since you have decided to become the new maintainer of slimlock I request that you integrate this change :)

Thanks!
