### PR TITLE
Add config option to set password mask character

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ are:
 -	`bell`: whether to ring the bell on authentication failure. 1 to
 	enable, 0 to disable.
 	-	Default: 1
+-	`passwd_char`: character to display when masking password. Only the first
+	character is used.
+	-	Default: *
 
 Copyright
 ---------

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -98,6 +98,7 @@ Cfg::Cfg()
     options.insert(option("show_welcome_msg", "0"));
     options.insert(option("tty_lock", "1"));
     options.insert(option("bell", "1"));
+    options.insert(option("passwd_char", "*"));
 
     error = "";
 }

--- a/panel.cpp
+++ b/panel.cpp
@@ -74,6 +74,8 @@ Panel::Panel(Display* dpy, int scr, Window win, Cfg* config,
     input_name_y = Cfg::string2int(cfg->getOption("input_name_y").c_str());
     input_pass_x = Cfg::string2int(cfg->getOption("input_pass_x").c_str());
     input_pass_y = Cfg::string2int(cfg->getOption("input_pass_y").c_str());
+    password_char = cfg->getOption("passwd_char").c_str()[0];
+
     inputShadowXOffset =
         Cfg::string2int(cfg->getOption("input_shadow_xoffset").c_str());
     inputShadowYOffset =
@@ -413,7 +415,7 @@ bool Panel::OnKeyPress(XEvent& event) {
                 formerString=HiddenPasswdBuffer;
                 if (PasswdBuffer.length() < INPUT_MAXLENGTH_PASSWD - 1) {
                     PasswdBuffer.push_back(ascii);
-                    HiddenPasswdBuffer.push_back('*');
+                    HiddenPasswdBuffer.push_back(password_char);
                 }
             } else {
                 fieldTextChanged = false;

--- a/panel.h
+++ b/panel.h
@@ -134,6 +134,7 @@ private:
     int password_y;
     std::string welcome_message;
     std::string intro_message;
+    char password_char;
 
     Image* image;
 

--- a/slimlock.1
+++ b/slimlock.1
@@ -57,5 +57,9 @@ message to display after a failed authentication attempt if the CapsLock is on.
 .B bell
 1 to enable the bell on authentication failure; 0 to disable.
 .BI "Default: " 1
+.TP
+.B passwd_char
+Character to show when masking password.
+.BI "Default: " *
 .SH "SEE ALSO"
 .BR slim (1)


### PR DESCRIPTION
I don't like using \* for masking passwords so I added a way to change the mask character from the configuration.  Any feedback is welcome.
