### PR TITLE
Added additional error handling for CFG/PAM

### DIFF
--- a/const.h
+++ b/const.h
@@ -14,6 +14,7 @@
 
 
 #define APPNAME    "slimlock"
+#define PAM_SERVICE_FILE "/etc/pam.d/" APPNAME
 
 #define DISPLAY    ":0.0"
 


### PR DESCRIPTION
I noticed that when I didn't do 'make install' before running slimlock, pam_start would return PAM_SUCCESS, despite not having /etc/pam.d/slimlock. This caused slimlock to spin in a loop and not accept input. Thought I would add these small changes to prevent this in the future (I dont like installing things right off the bat)
